### PR TITLE
Remove assumption about the roles path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ run any task itself.
 ```yaml
 - name: Include check-mode detection
   tags: "{{ role_name }}"
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/checkmodedetection.yml"
+  include: "{{ role_path }}/../silpion.lib/tasks/checkmodedetection.yml"
 ```
 
 ```yaml
 - name: Include data persistency paradigm
   tags: "{{ role_name }}"
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/datapersistency.yml"
+  include: "{{ role_path }}/../silpion.lib/tasks/datapersistency.yml"
 ```
 
 ```yaml
@@ -22,7 +22,7 @@ run any task itself.
 
 - name: Download some asset
   tags: "{{ role_name }}"
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/get_url.yml"
+  include: "{{ role_path }}/../silpion.lib/tasks/get_url.yml"
   vars:
     url: "{{ url_variable }}"
     filename: "{{ filename_variable }}"
@@ -34,7 +34,7 @@ run any task itself.
 
 - name: Upload downloaded asset
   tags: "{{ role_name }}"
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/copy.yml"
+  include: "{{ role_path }}/../silpion.lib/tasks/copy.yml"
   vars:
     filename: "{{ filename_variable }}"
 ```
@@ -46,7 +46,7 @@ run any task itself.
 
 - name: Include OS specific configuration
   tags: "{{ role_name }}"
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/os-specific-vars.yml"
+  include: "{{ role_path }}/../silpion.lib/tasks/os-specific-vars.yml"
 ```
 
 ```yaml
@@ -54,7 +54,7 @@ run any task itself.
 
 - name: Include version specific configuration
   tags: "{{ role_name }}"
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/version-specific-vars.yml
+  include: "{{ role_path }}/../silpion.lib/tasks/version-specific-vars.yml
   vars:
     version: "{{ role_name_version }}"
 ```
@@ -62,7 +62,7 @@ run any task itself.
 ```yaml
 - name: Include local facts installation
   tags: "{{ role_name }}"
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/localfacts.yml
+  include: "{{ role_path }}/../silpion.lib/tasks/localfacts.yml
   vars:
     template: myrolesfactstemplate.j2
     namespace: myroleshortname
@@ -70,10 +70,8 @@ run any task itself.
 
 # Assumption
 
-Assumption on using silpion.lib is that roles for a playbook are installed
-in a directory called `roles` beneath `playbook.yml`. Otherwise defaults/
-fallbacks when including os-specific or version-specific variables might
-fail unrelated.
+Assumption on using silpion.lib is that all the roles for a playbook are
+installed in the same directory.
 
 ## role-aware includes
 
@@ -178,7 +176,7 @@ Uploads will be stored in ``{{ lib_persistent_data_path_remote }}``.
   with_items:
     - filename1
     - filename2
-  include: "{{ playbook_dir }}/roles/silpion.lib/tasks/copy.yml"
+  include: "{{ role_path }}/../silpion.lib/tasks/copy.yml"
   vars:
     filename: "{{ item }}"
 ```

--- a/tasks/os-specific-vars.yml
+++ b/tasks/os-specific-vars.yml
@@ -11,5 +11,5 @@
   with_first_found:
     - "vars/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
     - "vars/{{ ansible_distribution }}.yml"
-    - "{{ playbook_dir }}/roles/silpion.lib/vars/os-specific/noop.yml"
+    - "{{ role_path }}/../silpion.lib/vars/os-specific/noop.yml"
   include_vars: "{{ item }}"

--- a/tasks/version-specific-vars.yml
+++ b/tasks/version-specific-vars.yml
@@ -7,5 +7,5 @@
 - name: Include version specific vars
   with_first_found:
     - "{{ role_path }}/vars/versions/{{ version }}.yml"
-    - "{{ playbook_dir }}/roles/silpion.lib/vars/versions/noop.yml"
+    - "{{ role_path }}/../silpion.lib/vars/versions/noop.yml"
   include_vars: "{{ item }}"


### PR DESCRIPTION
This removes the assumption that roles for a playbook are installed in a
directory called `roles` beneath `playbook.yml` (which can make the including
of os-specific or version-specific variables fail).

Instead, this assumes that all roles are checked out in a same directory.
This will break implementations where roles that use silpion.lib are installed
in a separate directory, but this use case should be less common than having
roles installed somewhere else than a directory called `roles` beneath
`playbook.yml`.
